### PR TITLE
Avoid triggering click event on key down, and set focus on search input after submit

### DIFF
--- a/src/applications/qa/index.js
+++ b/src/applications/qa/index.js
@@ -17,11 +17,11 @@
  */
 
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import _ from "lodash";
 
-import { Search, Button } from "@carbon/react";
+import { Search, Form, Button } from "@carbon/react";
 
 import Collections from "../../components/collections";
 import Retrievers from "../../components/retrievers";
@@ -125,6 +125,8 @@ function QuestionAnswering({ application, showSettings }) {
   const readers = useSelector((state) => state.readers);
   const dispatch = useDispatch();
 
+  const searchRef = useRef(null);
+
   return (
     <div className="application">
       <div className="application__body">
@@ -133,10 +135,32 @@ function QuestionAnswering({ application, showSettings }) {
         </div>
         <div className="application__content">
           <h4>What would you like to know?</h4>
-          <div className="qa__input">
+          <Form className="qa__input"
+            onSubmit={evt => {
+              evt.preventDefault();
+
+              // Step 1: Set processing to true
+              setProcessing(true);
+
+              // Step 2: Trigger ask function
+              ask(
+                questionText,
+                retrievers.selectedRetriever,
+                selectedCollection,
+                readers.selectedReader,
+                setAnswers,
+                setProcessing,
+                setProcessed,
+                dispatch
+              );
+
+              searchRef.current.focus();
+            }}
+          >
             <div className="qa__input--box">
               <Search
                 id="qa__question"
+                ref={searchRef}
                 labelText={questionText}
                 placeholder={strings.PLACEHOLDER_QUESTION}
                 disabled={
@@ -154,20 +178,6 @@ function QuestionAnswering({ application, showSettings }) {
                   setShowSuggestedQuestions(false);
                   setProcessed(false);
                   setQuestionText(event.target.value);
-                }}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    ask(
-                      questionText,
-                      retrievers.selectedRetriever,
-                      selectedCollection,
-                      readers.selectedReader,
-                      setAnswers,
-                      setProcessing,
-                      setProcessed,
-                      dispatch
-                    );
-                  }
                 }}
                 onClick={() => {
                   setShowSuggestedQuestions(true);
@@ -205,40 +215,8 @@ function QuestionAnswering({ application, showSettings }) {
               ) : null}
             </div>
             <Button
-              className="qa__question--submit-btn"
               kind="primary"
-              onClick={() => {
-                // Step 1: Set processing to true
-                setProcessing(true);
-
-                // Step 2: Trigger ask function
-                ask(
-                  questionText,
-                  retrievers.selectedRetriever,
-                  selectedCollection,
-                  readers.selectedReader,
-                  setAnswers,
-                  setProcessing,
-                  setProcessed,
-                  dispatch
-                );
-              }}
-              onKeyDown={() => {
-                // Step 1: Set processing to true
-                setProcessing(true);
-
-                // Step 2: Trigger ask function
-                ask(
-                  questionText,
-                  retrievers.selectedRetriever,
-                  selectedCollection,
-                  readers.selectedReader,
-                  setAnswers,
-                  setProcessing,
-                  setProcessed,
-                  dispatch
-                );
-              }}
+              type="submit"
               disabled={
                 disabled ||
                 !retrievers.selectedRetriever ||
@@ -249,7 +227,7 @@ function QuestionAnswering({ application, showSettings }) {
             >
               Ask
             </Button>
-          </div>
+          </Form>
           {questionText !== strings.PLACEHOLDER_QUESTION ? (
             <div className="answers">
               {(processing || processed) && questionText ? (

--- a/src/applications/qa/index.js
+++ b/src/applications/qa/index.js
@@ -125,6 +125,7 @@ function QuestionAnswering({ application, showSettings }) {
   const readers = useSelector((state) => state.readers);
   const dispatch = useDispatch();
 
+  // Reference for search input
   const searchRef = useRef(null);
 
   return (
@@ -154,6 +155,7 @@ function QuestionAnswering({ application, showSettings }) {
                 dispatch
               );
 
+              // Sets the focus on search input, accessing it through its reference
               searchRef.current.focus();
             }}
           >

--- a/src/applications/reading/index.js
+++ b/src/applications/reading/index.js
@@ -17,11 +17,11 @@
  */
 
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import _ from "lodash";
 
-import { TextArea, TextInput, Button } from "@carbon/react";
+import { TextArea, TextInput, Form, Button } from "@carbon/react";
 
 import Readers from "../../components/readers";
 import Answers from "../../components/answers";
@@ -117,6 +117,8 @@ function Reading({ application, showSettings }) {
   const readers = useSelector((state) => state.readers);
   const dispatch = useDispatch();
 
+  const questionRef = useRef(null);
+
   return (
     <div className="application">
       <div className="application__body">
@@ -137,9 +139,30 @@ function Reading({ application, showSettings }) {
                 setContext(event.target.value);
               }}
             ></TextArea>
-            <div className="reading__input--box">
+            <Form className="reading__input--box"
+              onSubmit={evt => {
+                evt.preventDefault();
+
+                // Step 1: Set processing to true
+                setProcessing(true);
+
+                // Step 2: Trigger read function
+                read(
+                  questionText,
+                  context,
+                  readers.selectedReader,
+                  setAnswers,
+                  setProcessing,
+                  setProcessed,
+                  dispatch
+                );
+
+                questionRef.current.focus();
+              }}
+            >
               <TextInput
                 id="reading__question"
+                ref={questionRef}
                 labelText={"Question"}
                 placeholder={strings.PLACEHOLDER_QUESTION}
                 disabled={disabled || !context || !readers.selectedReader}
@@ -152,53 +175,10 @@ function Reading({ application, showSettings }) {
                   setProcessed(false);
                   setQuestionText(event.target.value);
                 }}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    read(
-                      questionText,
-                      context,
-                      readers.selectedReader,
-                      setAnswers,
-                      setProcessing,
-                      setProcessed,
-                      dispatch
-                    );
-                  }
-                }}
               ></TextInput>
               <Button
-                className="reading__question--submit-btn"
                 kind="primary"
-                onClick={() => {
-                  // Step 1: Set processing to true
-                  setProcessing(true);
-
-                  // Step 2: Trigger ask function
-                  read(
-                    questionText,
-                    context,
-                    readers.selectedReader,
-                    setAnswers,
-                    setProcessing,
-                    setProcessed,
-                    dispatch
-                  );
-                }}
-                onKeyDown={() => {
-                  // Step 1: Set processing to true
-                  setProcessing(true);
-
-                  // Step 2: Trigger ask function
-                  read(
-                    questionText,
-                    context,
-                    readers.selectedReader,
-                    setAnswers,
-                    setProcessing,
-                    setProcessed,
-                    dispatch
-                  );
-                }}
+                type="submit"
                 disabled={
                   disabled ||
                   !context ||
@@ -208,7 +188,7 @@ function Reading({ application, showSettings }) {
               >
                 Ask
               </Button>
-            </div>
+            </Form>
           </div>
           {questionText !== strings.PLACEHOLDER_QUESTION ? (
             <div className="answers">

--- a/src/applications/reading/index.js
+++ b/src/applications/reading/index.js
@@ -117,6 +117,7 @@ function Reading({ application, showSettings }) {
   const readers = useSelector((state) => state.readers);
   const dispatch = useDispatch();
 
+  // Reference for question input
   const questionRef = useRef(null);
 
   return (
@@ -157,6 +158,7 @@ function Reading({ application, showSettings }) {
                   dispatch
                 );
 
+                // Sets the focus on question input, accessing it through its reference
                 questionRef.current.focus();
               }}
             >

--- a/src/applications/retrieval/index.js
+++ b/src/applications/retrieval/index.js
@@ -17,10 +17,10 @@
  */
 
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
 
-import { Search, Button } from "@carbon/react";
+import { Search, Form, Button } from "@carbon/react";
 
 import Collections from "../../components/collections";
 import Retrievers from "../../components/retrievers";
@@ -103,6 +103,8 @@ function Retrieval({ application, showSettings }) {
   const retrievers = useSelector((state) => state.retrievers);
   const dispatch = useDispatch();
 
+  const searchRef = useRef(null);
+
   return (
     <div className="application">
       <div className="application__body">
@@ -111,10 +113,31 @@ function Retrieval({ application, showSettings }) {
         </div>
         <div className="application__content">
           <h4>What would you like to know?</h4>
-          <div className="qa__input">
+          <Form className="qa__input"
+            onSubmit={evt => {
+              evt.preventDefault();
+
+              // Step 1: Set processing to true
+              setProcessing(true);
+
+              // Step 2: Trigger ask function
+              ask(
+                questionText,
+                retrievers.selectedRetriever,
+                selectedCollection,
+                setDocuments,
+                setProcessing,
+                setProcessed,
+                dispatch
+              );
+
+              searchRef.current.focus();
+            }}
+          >
             <div className="qa__input--box">
               <Search
                 id="qa__question"
+                ref={searchRef}
                 labelText={questionText}
                 placeholder={strings.PLACEHOLDER_QUESTION}
                 disabled={
@@ -181,38 +204,8 @@ function Retrieval({ application, showSettings }) {
               ) : null}
             </div>
             <Button
-              className="qa__question--submit-btn"
               kind="primary"
-              onClick={() => {
-                // Step 1: Set processing to true
-                setProcessing(true);
-
-                // Step 2: Trigger ask function
-                ask(
-                  questionText,
-                  retrievers.selectedRetriever,
-                  selectedCollection,
-                  setDocuments,
-                  setProcessing,
-                  setProcessed,
-                  dispatch
-                );
-              }}
-              onKeyDown={() => {
-                // Step 1: Set processing to true
-                setProcessing(true);
-
-                // Step 2: Trigger ask function
-                ask(
-                  questionText,
-                  retrievers.selectedRetriever,
-                  selectedCollection,
-                  setDocuments,
-                  setProcessing,
-                  setProcessed,
-                  dispatch
-                );
-              }}
+              type="submit"
               disabled={
                 disabled ||
                 !retrievers.selectedRetriever ||
@@ -222,7 +215,7 @@ function Retrieval({ application, showSettings }) {
             >
               Ask
             </Button>
-          </div>
+          </Form>
           {questionText !== strings.PLACEHOLDER_QUESTION ? (
             <div className="documents">
               {(processing || processed) && questionText ? (

--- a/src/applications/retrieval/index.js
+++ b/src/applications/retrieval/index.js
@@ -103,6 +103,7 @@ function Retrieval({ application, showSettings }) {
   const retrievers = useSelector((state) => state.retrievers);
   const dispatch = useDispatch();
 
+  // Reference for search input
   const searchRef = useRef(null);
 
   return (
@@ -131,6 +132,7 @@ function Retrieval({ application, showSettings }) {
                 dispatch
               );
 
+              // Sets the focus on search input, accessing it through its reference
               searchRef.current.focus();
             }}
           >


### PR DESCRIPTION
This PR fixes the behavior of triggering the request on any key down, implementing form submit behavior. Additionally, sets the focus on the search input after submitting. Implemented in Retrieval, Reading and QA.